### PR TITLE
Fixes crash on restart (Android)

### DIFF
--- a/src/app-sync.ts
+++ b/src/app-sync.ts
@@ -299,17 +299,16 @@ export class AppSync {
   private static killApp(restartOnAndroid: boolean): void {
     if (Application.android) {
       if (restartOnAndroid) {
+        const packageManager = Application.android.context.getPackageManager();
+        const intent = packageManager.getLaunchIntentForPackage(Application.android.context.getPackageName());
+        const componentName = intent.getComponent();
+
         //noinspection JSUnresolvedFunction,JSUnresolvedVariable
-        const mStartActivity = new android.content.Intent(Application.android.context, Application.android.startActivity.getClass());
-        const mPendingIntentId = parseInt("" + (Math.random() * 100000), 10);
-        //noinspection JSUnresolvedFunction,JSUnresolvedVariable
-        const mPendingIntent = android.app.PendingIntent.getActivity(Application.android.context, mPendingIntentId, mStartActivity, android.app.PendingIntent.FLAG_CANCEL_CURRENT);
-        //noinspection JSUnresolvedFunction,JSUnresolvedVariable
-        const mgr = Application.android.context.getSystemService(android.content.Context.ALARM_SERVICE);
-        //noinspection JSUnresolvedFunction,JSUnresolvedVariable
-        mgr.set(android.app.AlarmManager.RTC, java.lang.System.currentTimeMillis() + 100, mPendingIntent);
+        const mainIntent = new android.content.Intent.makeRestartActivityTask(componentName);
+        Application.android.context.startActivity(mainIntent);
         //noinspection JSUnresolvedFunction,JSUnresolvedVariable
       }
+      //noinspection JSUnresolvedFunction,JSUnresolvedVariable
       android.os.Process.killProcess(android.os.Process.myPid());
     } else if (Application.ios) {
       exit(0);


### PR DESCRIPTION
When the option to restart the app on install is clicked the app closes and does not restart.

Then when you manually launch the app you get the below error

> An uncaught Exception occurred on "main" thread.
> Unable to start activity ComponentInfo{org.finitydevs.link/com.tns.NativeScriptActivity}: com.tns.NativeScriptException: Calling js method onCreate failed
> TypeError: Cannot read property 'nativeView' of undefined

Appsync was using a timer-based method to launch the app and quit the current one
When I switched to using an [android Intent makeRestartActivityTask](https://developer.android.com/reference/android/content/Intent#makeRestartActivityTask(android.content.ComponentName)) all the problems were resolved and the app restarts with its new assets beautifully

This only applies to Android
 
